### PR TITLE
Python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 language: python
 
 python:
-- '3.6'
+- '3.8'
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM hepdata/hepdata-converter:0.2.0
 
-RUN pip install --upgrade pip
-RUN pip install -I hepdata-converter-ws==0.1.7
+RUN pip3 install --upgrade pip
+RUN pip3 install -I hepdata-converter-ws==0.2.0
 
 CMD hepdata-converter-ws

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hepdata/hepdata-converter
+FROM hepdata/hepdata-converter:0.2.0
 
 COPY requirements.txt /tmp/requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 hepdata-converter
 hepdata-converter-ws
+distlib
 flask
 flask-testing


### PR DESCRIPTION
This now works based on the docker image build from [the DurhamARC python3 branch](/DurhamARC/hepdata-converter-docker/tree/feature/python3).

We shouldn't merge this PR until both HEPData/hepdata-converter-docker#2 and HEPData/hepdata-converter-ws#7 have been fixed and the respective new docker image and pypi package have been published.

Fixes #1 